### PR TITLE
Add support for .mpl imported files

### DIFF
--- a/iGenomics/iGenomics-Info.plist
+++ b/iGenomics/iGenomics-Info.plist
@@ -36,6 +36,20 @@
 				<string>com.igenomics.doctype.fastq</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
+			<key>CFBundleTypeName</key>
+			<string>Known Mutations File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.igenomics.doctype.mpl</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
@@ -143,6 +157,23 @@
 				<array>
 					<string>fastq</string>
 					<string>fq</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Standard Known Mutations File Format</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.igenomics.doctype.mpl</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mpl</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
It seems the code for supporting external .mpl files once in iGenomics was already added in the past so this PR is really just adding the necessary metadata to the info.plist to get iGenomics to show up when other apps (e.g. Google Drive, gmail, messenger, etc.) have a .mpl file that they want to open

Closes #17 